### PR TITLE
Add support for HTTPS with secure port configuration in Traefik

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -12,6 +12,9 @@ traefik:
     traefik-port:
       value: 8085
       type: int
+    http-secure-port:
+      value: 443
+      type: int
   files:
     traefik-config:
       container: traefik
@@ -23,6 +26,22 @@ traefik:
         entryPoints:
           web:
             address: ":80"
+            http:
+              redirections:
+                entryPoint:
+                  to: websecure
+                  scheme: https
+                  permanent: true
+          websecure:
+            address: ":443"
+            asDefault: true
+            http:
+              tls: {}
+        certificatesresolvers:
+          monkresolver:
+            acme:
+              tlschallenge: true
+              storage: /letsencrypt/acme.json
         providers:
           file:
             directory: /etc/traefik/dynamic
@@ -34,12 +53,19 @@ traefik:
       image: traefik:v3.4.3
       paths:
         - <- `${configs-dir}:/etc/traefik/dynamic`
+        - <- `${volume-path}/letsencrypt:/letsencrypt`
   services:
     web:
       container: traefik
       port: 80
       protocol: tcp
       host-port: <- $http-port
+      publish: true
+    websecure:
+      container: traefik
+      port: 443
+      protocol: tcp
+      host-port: <- $http-secure-port
       publish: true
     traefik:
       container: traefik
@@ -64,6 +90,9 @@ traefik-waf:
     http-port:
       value: 80
       type: int
+    http-secure-port:
+      value: 443
+      type: int
   connections:
     waf-conn:
       runnable: system/waf
@@ -79,6 +108,22 @@ traefik-waf:
         entryPoints:
           web:
             address: ":80"
+            http:
+              redirections:
+                entryPoint:
+                  to: websecure
+                  scheme: https
+                  permanent: true
+          websecure:
+            address: ":443"
+            asDefault: true
+            http:
+              tls: {}
+        certificatesresolvers:
+          monkresolver:
+            acme:
+              tlschallenge: true
+              storage: /letsencrypt/acme.json
         providers:
           file:
             directory: /etc/traefik/dynamic
@@ -95,12 +140,19 @@ traefik-waf:
       image: traefik:v3.4.3
       paths:
         - <- `${configs-dir}:/etc/traefik/dynamic`
+        - <- `${volume-path}/letsencrypt:/letsencrypt`
   services:
     web:
       container: traefik
       port: 80
       protocol: tcp
       host-port: <- $http-port
+      publish: true
+    websecure:
+      container: traefik
+      port: 443
+      protocol: tcp
+      host-port: <- $http-secure-port
       publish: true
     traefik:
       container: traefik


### PR DESCRIPTION
This pull request updates the `manifest.yaml` configuration for both the `traefik` and `traefik-waf` components to enable secure HTTPS support and automatic redirection from HTTP to HTTPS. It also adds certificate management using ACME and Let's Encrypt, and exposes the new secure service ports.

**HTTPS Enablement and Redirection:**

* Added `websecure` entry point on port 443 with TLS enabled, and configured HTTP (`web` on port 80) to automatically redirect all traffic to HTTPS (`websecure`). [[1]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6R29-R44) [[2]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6R111-R126)
* Exposed new `http-secure-port` variable and mapped the secure port in both `traefik` and `traefik-waf` services, making HTTPS available externally. [[1]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6R15-R17) [[2]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6R93-R95) [[3]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6R56-R69) [[4]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6R143-R156)

**Certificate Management:**

* Configured ACME certificate resolver (`monkresolver`) with TLS challenge for automatic certificate provisioning, and mounted a persistent volume for certificate storage. [[1]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6R29-R44) [[2]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6R111-R126) [[3]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6R56-R69) [[4]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6R143-R156)