### PR TITLE
Add TLS certificate and key configuration for Traefik

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -15,7 +15,23 @@ traefik:
     http-secure-port:
       value: 443
       type: int
+    tls-cert:
+      type: string
+      value: ""
+    tls-key:
+      type: string
+      value: ""
   files:
+    tls-cert:
+      container: traefik
+      path: /certs/tls.crt
+      mode: 511
+      contents: <- $tls-cert default("")
+    tls-key:
+      container: traefik
+      path: /certs/tls.key
+      mode: 511
+      contents: <- $tls-key default("")
     traefik-config:
       container: traefik
       path: /etc/traefik/traefik.yml
@@ -37,11 +53,6 @@ traefik:
             asDefault: true
             http:
               tls: {}
-        certificatesresolvers:
-          monkresolver:
-            acme:
-              tlschallenge: true
-              storage: /letsencrypt/acme.json
         providers:
           file:
             directory: /etc/traefik/dynamic
@@ -53,7 +64,6 @@ traefik:
       image: traefik:v3.4.3
       paths:
         - <- `${configs-dir}:/etc/traefik/dynamic`
-        - <- `${volume-path}/letsencrypt:/letsencrypt`
   services:
     web:
       container: traefik
@@ -93,11 +103,27 @@ traefik-waf:
     http-secure-port:
       value: 443
       type: int
+    tls-cert:
+      type: string
+      value: ""
+    tls-key:
+      type: string
+      value: ""
   connections:
     waf-conn:
       runnable: system/waf
       service: waf
   files:
+    tls-cert:
+      container: traefik
+      path: /certs/tls.crt
+      mode: 511
+      contents: <- $tls-cert default("")
+    tls-key:
+      container: traefik
+      path: /certs/tls.key
+      mode: 511
+      contents: <- $tls-key default("")
     traefik-config:
       container: traefik
       path: /etc/traefik/traefik.yml
@@ -119,11 +145,6 @@ traefik-waf:
             asDefault: true
             http:
               tls: {}
-        certificatesresolvers:
-          monkresolver:
-            acme:
-              tlschallenge: true
-              storage: /letsencrypt/acme.json
         providers:
           file:
             directory: /etc/traefik/dynamic
@@ -140,7 +161,6 @@ traefik-waf:
       image: traefik:v3.4.3
       paths:
         - <- `${configs-dir}:/etc/traefik/dynamic`
-        - <- `${volume-path}/letsencrypt:/letsencrypt`
   services:
     web:
       container: traefik


### PR DESCRIPTION
This pull request updates the `manifest.yaml` configuration for both the `traefik` and `traefik-waf` components to move from automatic ACME certificate management to manual TLS certificate provisioning. The changes introduce new configuration variables and file mappings for TLS certificates and remove ACME-related settings, simplifying the setup and making certificate management explicit.

TLS Certificate Management Updates:

* Added new variables `tls-cert` and `tls-key` to both `traefik` and `traefik-waf` for manual TLS certificate and key input, along with corresponding file mappings to mount these files into the containers at `/certs/tls.crt` and `/certs/tls.key`. [[1]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6R18-R34) [[2]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6R106-R126)

Removal of ACME/Let's Encrypt Automation:

* Removed the `certificatesresolvers` and ACME configuration (including `tlschallenge` and storage for Let's Encrypt) from both `traefik` and `traefik-waf` HTTP entrypoints, disabling automatic certificate issuance. [[1]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6L40-L44) [[2]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6L122-L126)
* Removed the volume mount for the Let's Encrypt storage directory (`/letsencrypt`) from both components, as it is no longer needed. [[1]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6L56) [[2]](diffhunk://#diff-d865b06b497efc8c56c63e5bedfc86f6da6a005cdb7d30e3702286f3d918aaa6L143)