### PR TITLE
Set Traefik log level to DEBUG for enhanced troubleshooting

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -58,7 +58,7 @@ traefik:
             directory: /etc/traefik/dynamic
             watch: true
         log:
-          level: INFO
+          level: DEBUG
   containers:
     traefik:
       image: traefik:v3.4.3


### PR DESCRIPTION
This pull request makes a small configuration change to the `manifest.yaml` file, adjusting the logging level for Traefik from `INFO` to `DEBUG` to provide more detailed logs.

* Set the Traefik log level to `DEBUG` in `manifest.yaml` for increased verbosity during troubleshooting.